### PR TITLE
refactor(cli): replace untyped Store with typed credential stores

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,12 +6,79 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
-// Store reads and writes JSON-serializable data.
+// ScaniaCredentials holds Scania rFMS OAuth2 client credentials.
+type ScaniaCredentials struct {
+	ClientID     string `json:"clientId"`
+	ClientSecret string `json:"clientSecret"`
+}
+
+// VolvoCredentials holds Volvo Trucks rFMS HTTP Basic credentials.
+type VolvoCredentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// ScaniaCredentialStore reads and writes Scania credentials.
+type ScaniaCredentialStore interface {
+	Load() (*ScaniaCredentials, error)
+	Save(*ScaniaCredentials) error
+	Clear() error
+}
+
+// VolvoCredentialStore reads and writes Volvo Trucks credentials.
+type VolvoCredentialStore interface {
+	Load() (*VolvoCredentials, error)
+	Save(*VolvoCredentials) error
+	Clear() error
+}
+
+// fileStore is a generic JSON file-backed credential store.
+type fileStore[T any] struct{ path string }
+
+func (s *fileStore[T]) Load() (*T, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return nil, fmt.Errorf("read credentials: %w", err)
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, fmt.Errorf("unmarshal credentials: %w", err)
+	}
+	return &v, nil
+}
+
+func (s *fileStore[T]) Save(v *T) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal credentials: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create credentials dir: %w", err)
+	}
+	return os.WriteFile(s.path, data, 0o600)
+}
+
+func (s *fileStore[T]) Clear() error {
+	err := os.Remove(s.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// NewScaniaCredentialFileStore creates a file-backed Scania credential store.
+func NewScaniaCredentialFileStore(path string) ScaniaCredentialStore {
+	return &fileStore[ScaniaCredentials]{path: path}
+}
+
+// NewVolvoCredentialFileStore creates a file-backed Volvo credential store.
+func NewVolvoCredentialFileStore(path string) VolvoCredentialStore {
+	return &fileStore[VolvoCredentials]{path: path}
+}
+
+// Store reads and writes JSON-serializable data. Used for token caching.
 type Store interface {
 	Read(target any) error
 	Write(data any) error
@@ -22,20 +89,20 @@ type Store interface {
 type Option func(*config)
 
 type config struct {
-	scaniaCredentialStore      Store
-	volvoTrucksCredentialStore Store
-	tokenStore                 Store
-	httpClient                 *http.Client
+	scaniaCredentialStore ScaniaCredentialStore
+	volvoCredentialStore  VolvoCredentialStore
+	tokenStore            Store
+	httpClient            *http.Client
 }
 
 // WithScaniaCredentialStore sets the credential store for Scania rFMS.
-func WithScaniaCredentialStore(s Store) Option {
+func WithScaniaCredentialStore(s ScaniaCredentialStore) Option {
 	return func(c *config) { c.scaniaCredentialStore = s }
 }
 
-// WithVolvoTrucksCredentialStore sets the credential store for Volvo Trucks rFMS.
-func WithVolvoTrucksCredentialStore(s Store) Option {
-	return func(c *config) { c.volvoTrucksCredentialStore = s }
+// WithVolvoCredentialStore sets the credential store for Volvo Trucks rFMS.
+func WithVolvoCredentialStore(s VolvoCredentialStore) Option {
+	return func(c *config) { c.volvoCredentialStore = s }
 }
 
 // WithTokenStore sets the token store (used for Scania OAuth2 tokens).
@@ -48,8 +115,7 @@ func WithHTTPClient(httpClient *http.Client) Option {
 	return func(c *config) { c.httpClient = httpClient }
 }
 
-// FileStore is a file-backed store that uses protojson for proto messages
-// and encoding/json for other types.
+// FileStore is a file-backed store that uses encoding/json for serialization.
 type FileStore struct {
 	path string
 }
@@ -65,12 +131,6 @@ func (s *FileStore) Read(target any) error {
 	if err != nil {
 		return fmt.Errorf("read store: %w", err)
 	}
-	if msg, ok := target.(proto.Message); ok {
-		if err := protojson.Unmarshal(data, msg); err != nil {
-			return fmt.Errorf("unmarshal store: %w", err)
-		}
-		return nil
-	}
 	if err := json.Unmarshal(data, target); err != nil {
 		return fmt.Errorf("unmarshal store: %w", err)
 	}
@@ -79,13 +139,7 @@ func (s *FileStore) Read(target any) error {
 
 // Write marshals data and writes it to the file.
 func (s *FileStore) Write(data any) error {
-	var out []byte
-	var err error
-	if msg, ok := data.(proto.Message); ok {
-		out, err = protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(msg)
-	} else {
-		out, err = json.MarshalIndent(data, "", "  ")
-	}
+	out, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal store: %w", err)
 	}

--- a/cli/command.go
+++ b/cli/command.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	rfms "github.com/way-platform/rfms-go"
-	scaniacreds "github.com/way-platform/rfms-go/proto/gen/go/wayplatform/connect/scania/rfms/v1"
-	volvocreds "github.com/way-platform/rfms-go/proto/gen/go/wayplatform/connect/volvotrucks/rfms/v1"
 	"golang.org/x/oauth2"
 	"golang.org/x/term"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -71,48 +69,50 @@ func newLoginScaniaCommand(cfg *config) *cobra.Command {
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		// Try loading stored credentials first.
-		creds := &scaniacreds.Credentials{}
+		creds := &ScaniaCredentials{}
 		if cfg.scaniaCredentialStore != nil {
-			if err := cfg.scaniaCredentialStore.Read(creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			if loaded, err := cfg.scaniaCredentialStore.Load(); err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("read credentials: %w", err)
+			} else if err == nil {
+				creds = loaded
 			}
 		}
 		// Override with flags.
 		if *clientID != "" {
-			creds.SetClientId(*clientID)
+			creds.ClientID = *clientID
 		}
 		if *clientSecret != "" {
-			creds.SetClientSecret(*clientSecret)
+			creds.ClientSecret = *clientSecret
 		}
 		// Prompt for missing fields.
-		if creds.GetClientId() == "" {
+		if creds.ClientID == "" {
 			val, err := promptSecret(cmd, "Enter OAuth2 client ID: ")
 			if err != nil {
 				return fmt.Errorf("read client ID: %w", err)
 			}
-			creds.SetClientId(val)
+			creds.ClientID = val
 		}
-		if creds.GetClientSecret() == "" {
+		if creds.ClientSecret == "" {
 			val, err := promptSecret(cmd, "Enter OAuth2 client secret: ")
 			if err != nil {
 				return fmt.Errorf("read client secret: %w", err)
 			}
-			creds.SetClientSecret(val)
+			creds.ClientSecret = val
 		}
 		// Persist credentials.
 		if cfg.scaniaCredentialStore != nil {
-			if err := cfg.scaniaCredentialStore.Write(creds); err != nil {
+			if err := cfg.scaniaCredentialStore.Save(creds); err != nil {
 				return fmt.Errorf("write credentials: %w", err)
 			}
 		}
 		// Clear Volvo credentials when switching provider.
-		if cfg.volvoTrucksCredentialStore != nil {
-			_ = cfg.volvoTrucksCredentialStore.Clear()
+		if cfg.volvoCredentialStore != nil {
+			_ = cfg.volvoCredentialStore.Clear()
 		}
 		// Run OAuth2 flow.
 		tokenSource := rfms.ScaniaAuthConfig{
-			ClientID:     creds.GetClientId(),
-			ClientSecret: creds.GetClientSecret(),
+			ClientID:     creds.ClientID,
+			ClientSecret: creds.ClientSecret,
 		}.TokenSource(context.Background())
 		token, err := tokenSource.Token()
 		if err != nil {
@@ -141,37 +141,39 @@ func newLoginVolvoTrucksCommand(cfg *config) *cobra.Command {
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		// Try loading stored credentials first.
-		creds := &volvocreds.Credentials{}
-		if cfg.volvoTrucksCredentialStore != nil {
-			if err := cfg.volvoTrucksCredentialStore.Read(creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		creds := &VolvoCredentials{}
+		if cfg.volvoCredentialStore != nil {
+			if loaded, err := cfg.volvoCredentialStore.Load(); err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("read credentials: %w", err)
+			} else if err == nil {
+				creds = loaded
 			}
 		}
 		// Override with flags.
 		if *username != "" {
-			creds.SetUsername(*username)
+			creds.Username = *username
 		}
 		if *password != "" {
-			creds.SetPassword(*password)
+			creds.Password = *password
 		}
 		// Prompt for missing fields.
-		if creds.GetUsername() == "" {
+		if creds.Username == "" {
 			val, err := promptSecret(cmd, "Enter username: ")
 			if err != nil {
 				return fmt.Errorf("read username: %w", err)
 			}
-			creds.SetUsername(val)
+			creds.Username = val
 		}
-		if creds.GetPassword() == "" {
+		if creds.Password == "" {
 			val, err := promptSecret(cmd, "Enter password: ")
 			if err != nil {
 				return fmt.Errorf("read password: %w", err)
 			}
-			creds.SetPassword(val)
+			creds.Password = val
 		}
 		// Persist credentials.
-		if cfg.volvoTrucksCredentialStore != nil {
-			if err := cfg.volvoTrucksCredentialStore.Write(creds); err != nil {
+		if cfg.volvoCredentialStore != nil {
+			if err := cfg.volvoCredentialStore.Save(creds); err != nil {
 				return fmt.Errorf("write credentials: %w", err)
 			}
 		}
@@ -200,8 +202,8 @@ func newLogoutCommand(cfg *config) *cobra.Command {
 					return fmt.Errorf("clear scania credentials: %w", err)
 				}
 			}
-			if cfg.volvoTrucksCredentialStore != nil {
-				if err := cfg.volvoTrucksCredentialStore.Clear(); err != nil {
+			if cfg.volvoCredentialStore != nil {
+				if err := cfg.volvoCredentialStore.Clear(); err != nil {
 					return fmt.Errorf("clear volvo credentials: %w", err)
 				}
 			}
@@ -344,8 +346,7 @@ func newClient(_ *cobra.Command, cfg *config) (*rfms.Client, error) {
 	}
 	// Try Scania credentials.
 	if cfg.scaniaCredentialStore != nil {
-		creds := &scaniacreds.Credentials{}
-		if err := cfg.scaniaCredentialStore.Read(creds); err == nil {
+		if _, err := cfg.scaniaCredentialStore.Load(); err == nil {
 			var token oauth2.Token
 			if cfg.tokenStore != nil {
 				if err := cfg.tokenStore.Read(&token); err != nil {
@@ -371,11 +372,10 @@ func newClient(_ *cobra.Command, cfg *config) (*rfms.Client, error) {
 		}
 	}
 	// Try Volvo Trucks credentials.
-	if cfg.volvoTrucksCredentialStore != nil {
-		creds := &volvocreds.Credentials{}
-		if err := cfg.volvoTrucksCredentialStore.Read(creds); err == nil {
+	if cfg.volvoCredentialStore != nil {
+		if creds, err := cfg.volvoCredentialStore.Load(); err == nil {
 			opts = append(opts,
-				rfms.WithVolvoTrucks(creds.GetUsername(), creds.GetPassword()),
+				rfms.WithVolvoTrucks(creds.Username, creds.Password),
 			)
 			return rfms.NewClient(opts...)
 		}

--- a/cmd/rfms/main.go
+++ b/cmd/rfms/main.go
@@ -20,8 +20,8 @@ func main() {
 	var debug bool
 	debugTransport := &rfms.DebugTransport{Enabled: &debug}
 	cmd := cli.NewCommand(
-		cli.WithScaniaCredentialStore(cli.NewFileStore(scaniaCredPath)),
-		cli.WithVolvoTrucksCredentialStore(cli.NewFileStore(volvoCredPath)),
+		cli.WithScaniaCredentialStore(cli.NewScaniaCredentialFileStore(scaniaCredPath)),
+		cli.WithVolvoCredentialStore(cli.NewVolvoCredentialFileStore(volvoCredPath)),
 		cli.WithTokenStore(cli.NewFileStore(tokenPath)),
 		cli.WithHTTPClient(&http.Client{Transport: debugTransport}),
 	)


### PR DESCRIPTION
## Summary

- Replace `Store` interface for credentials with typed `ScaniaCredentialStore` and `VolvoCredentialStore` interfaces
- Add private generic `fileStore[T]` with typed constructors
- Remove credential provider functions — store is the single injection point
- Simplify resolve functions to single-path logic
- Rename `WithVolvoTrucksCredentialStore` to `WithVolvoCredentialStore`
- Keep untyped `Store`/`FileStore` for token store (orthogonal)

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`