### PR TITLE
feat(cli): replace untyped token Store with typed TokenStore

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/oauth2"
 )
 
 // ScaniaCredentials holds Scania rFMS OAuth2 client credentials.
@@ -78,11 +80,16 @@ func NewVolvoCredentialFileStore(path string) VolvoCredentialStore {
 	return &fileStore[VolvoCredentials]{path: path}
 }
 
-// Store reads and writes JSON-serializable data. Used for token caching.
-type Store interface {
-	Read(target any) error
-	Write(data any) error
+// TokenStore reads and writes OAuth2 tokens.
+type TokenStore interface {
+	Load() (*oauth2.Token, error)
+	Save(*oauth2.Token) error
 	Clear() error
+}
+
+// NewTokenFileStore creates a file-backed token store.
+func NewTokenFileStore(path string) TokenStore {
+	return &fileStore[oauth2.Token]{path: path}
 }
 
 // Option configures the CLI command tree.
@@ -91,7 +98,7 @@ type Option func(*config)
 type config struct {
 	scaniaCredentialStore ScaniaCredentialStore
 	volvoCredentialStore  VolvoCredentialStore
-	tokenStore            Store
+	tokenStore            TokenStore
 	httpClient            *http.Client
 }
 
@@ -106,54 +113,11 @@ func WithVolvoCredentialStore(s VolvoCredentialStore) Option {
 }
 
 // WithTokenStore sets the token store (used for Scania OAuth2 tokens).
-func WithTokenStore(s Store) Option {
+func WithTokenStore(s TokenStore) Option {
 	return func(c *config) { c.tokenStore = s }
 }
 
 // WithHTTPClient sets the base [http.Client] passed to the SDK client.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(c *config) { c.httpClient = httpClient }
-}
-
-// FileStore is a file-backed store that uses encoding/json for serialization.
-type FileStore struct {
-	path string
-}
-
-// NewFileStore creates a new file-backed store at the given path.
-func NewFileStore(path string) *FileStore {
-	return &FileStore{path: path}
-}
-
-// Read unmarshals the file contents into target.
-func (s *FileStore) Read(target any) error {
-	data, err := os.ReadFile(s.path)
-	if err != nil {
-		return fmt.Errorf("read store: %w", err)
-	}
-	if err := json.Unmarshal(data, target); err != nil {
-		return fmt.Errorf("unmarshal store: %w", err)
-	}
-	return nil
-}
-
-// Write marshals data and writes it to the file.
-func (s *FileStore) Write(data any) error {
-	out, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal store: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
-		return fmt.Errorf("create store dir: %w", err)
-	}
-	return os.WriteFile(s.path, out, 0o600)
-}
-
-// Clear removes the file.
-func (s *FileStore) Clear() error {
-	err := os.Remove(s.path)
-	if err != nil && os.IsNotExist(err) {
-		return nil
-	}
-	return err
 }

--- a/cli/command.go
+++ b/cli/command.go
@@ -120,7 +120,7 @@ func newLoginScaniaCommand(cfg *config) *cobra.Command {
 		}
 		// Cache token.
 		if cfg.tokenStore != nil {
-			if err := cfg.tokenStore.Write(token); err != nil {
+			if err := cfg.tokenStore.Save(token); err != nil {
 				return fmt.Errorf("write token: %w", err)
 			}
 		}
@@ -347,9 +347,9 @@ func newClient(_ *cobra.Command, cfg *config) (*rfms.Client, error) {
 	// Try Scania credentials.
 	if cfg.scaniaCredentialStore != nil {
 		if _, err := cfg.scaniaCredentialStore.Load(); err == nil {
-			var token oauth2.Token
 			if cfg.tokenStore != nil {
-				if err := cfg.tokenStore.Read(&token); err != nil {
+				token, err := cfg.tokenStore.Load()
+				if err != nil {
 					if errors.Is(err, fs.ErrNotExist) {
 						return nil, fmt.Errorf(
 							"session expired, please login again using `rfms auth login scania`",
@@ -357,17 +357,17 @@ func newClient(_ *cobra.Command, cfg *config) (*rfms.Client, error) {
 					}
 					return nil, fmt.Errorf("read token: %w", err)
 				}
-			}
-			if !token.Valid() {
-				return nil, fmt.Errorf(
-					"session expired, please login again using `rfms auth login scania`",
+				if !token.Valid() {
+					return nil, fmt.Errorf(
+						"session expired, please login again using `rfms auth login scania`",
+					)
+				}
+				opts = append(opts,
+					rfms.WithBaseURL(rfms.ScaniaBaseURL),
+					rfms.WithVersion(rfms.V4),
+					rfms.WithTokenSource(oauth2.StaticTokenSource(token)),
 				)
 			}
-			opts = append(opts,
-				rfms.WithBaseURL(rfms.ScaniaBaseURL),
-				rfms.WithVersion(rfms.V4),
-				rfms.WithTokenSource(oauth2.StaticTokenSource(&token)),
-			)
 			return rfms.NewClient(opts...)
 		}
 	}

--- a/cmd/rfms/main.go
+++ b/cmd/rfms/main.go
@@ -22,7 +22,7 @@ func main() {
 	cmd := cli.NewCommand(
 		cli.WithScaniaCredentialStore(cli.NewScaniaCredentialFileStore(scaniaCredPath)),
 		cli.WithVolvoCredentialStore(cli.NewVolvoCredentialFileStore(volvoCredPath)),
-		cli.WithTokenStore(cli.NewFileStore(tokenPath)),
+		cli.WithTokenStore(cli.NewTokenFileStore(tokenPath)),
 		cli.WithHTTPClient(&http.Client{Transport: debugTransport}),
 	)
 	cmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug logging of HTTP requests")


### PR DESCRIPTION
## Summary

- Add `TokenStore` interface (`Load()/Save()/Clear()`) for `oauth2.Token`
- Add `NewTokenFileStore` constructor using existing generic `fileStore[T]`
- Delete untyped `Store` interface, `FileStore`, and `NewFileStore`
- All store interfaces are now typed: no more `any` parameters

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`