### PR TITLE
chore: add BufPush mage target

### DIFF
--- a/tools/magefile.go
+++ b/tools/magefile.go
@@ -77,6 +77,12 @@ func CLI() error {
 	return cmd(root("cmd/rfms"), "go", "install", ".").Run()
 }
 
+// BufPush pushes the proto module to the Buf Schema Registry.
+func BufPush() error {
+	log.Println("pushing proto module to BSR")
+	return tool(root("proto"), "buf", "push").Run()
+}
+
 // Diff checks for git diffs.
 func Diff() error {
 	log.Println("checking for git diffs")


### PR DESCRIPTION
## Summary

- Adds `BufPush` mage target to `tools/magefile.go`
- Runs `buf push` from the `proto/` directory to publish the proto module to the Buf Schema Registry (`buf.build/way-platform/rfms`)
- Prerequisite for including OSS SDK schemas in the monorepo CLI's descriptor set

## Test plan

```bash
cd tools && mage BufPush
```