### PR TITLE
refactor: use connect error codes instead of custom Error type

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,232 @@
+package rfms_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	rfms "github.com/way-platform/rfms-go"
+	rfmsv5 "github.com/way-platform/rfms-go/proto/gen/go/wayplatform/connect/rfms/v5"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *rfms.Client {
+	t.Helper()
+	client, err := rfms.NewClient(
+		rfms.WithBaseURL(srv.URL),
+		rfms.WithVersion(rfms.V4),
+		rfms.WithBasicAuth("test", "test"),
+		rfms.WithRetryCount(0),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestVehicles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vehicles" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"moreDataAvailable": false,
+			"vehicleResponse": map[string]any{
+				"vehicles": []map[string]any{
+					{"vin": "YS2R4X20009876543"},
+					{"vin": "WDB96340310987654"},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	resp, err := client.Vehicles(context.Background(), rfmsv5.VehiclesRequest_builder{}.Build())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.GetVehicles()); got != 2 {
+		t.Fatalf("expected 2 vehicles, got %d", got)
+	}
+	if got := resp.GetVehicles()[0].GetVin(); got != "YS2R4X20009876543" {
+		t.Fatalf("expected VIN YS2R4X20009876543, got %s", got)
+	}
+	if got := resp.GetVehicles()[1].GetVin(); got != "WDB96340310987654" {
+		t.Fatalf("expected VIN WDB96340310987654, got %s", got)
+	}
+	if resp.GetMoreDataAvailable() {
+		t.Fatal("expected moreDataAvailable=false")
+	}
+}
+
+func TestVehiclePositions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vehiclepositions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"moreDataAvailable": false,
+			"vehiclePositionResponse": map[string]any{
+				"vehiclePositions": []map[string]any{
+					{
+						"vin": "YS2R4X20009876543",
+						"gnssPosition": map[string]any{
+							"latitude":  57.7089,
+							"longitude": 11.9746,
+						},
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	req := rfmsv5.VehiclePositionsRequest_builder{}.Build()
+	resp, err := client.VehiclePositions(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.GetVehiclePositions()); got != 1 {
+		t.Fatalf("expected 1 position, got %d", got)
+	}
+	pos := resp.GetVehiclePositions()[0]
+	if got := pos.GetVin(); got != "YS2R4X20009876543" {
+		t.Fatalf("expected VIN YS2R4X20009876543, got %s", got)
+	}
+}
+
+func TestVehicleStatuses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vehiclestatuses" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"moreDataAvailable": false,
+			"vehicleStatusResponse": map[string]any{
+				"vehicleStatuses": []map[string]any{
+					{
+						"vin":             "YS2R4X20009876543",
+						"createdDateTime": "2024-01-15T10:30:00Z",
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	req := rfmsv5.VehicleStatusesRequest_builder{}.Build()
+	resp, err := client.VehicleStatuses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.GetVehicleStatuses()); got != 1 {
+		t.Fatalf("expected 1 status, got %d", got)
+	}
+	status := resp.GetVehicleStatuses()[0]
+	if got := status.GetVin(); got != "YS2R4X20009876543" {
+		t.Fatalf("expected VIN YS2R4X20009876543, got %s", got)
+	}
+}
+
+func TestErrorCodeMapping(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		wantCode   connect.Code
+	}{
+		{http.StatusBadRequest, connect.CodeInvalidArgument},
+		{http.StatusUnauthorized, connect.CodeUnauthenticated},
+		{http.StatusForbidden, connect.CodePermissionDenied},
+		{http.StatusNotFound, connect.CodeNotFound},
+		{http.StatusConflict, connect.CodeAlreadyExists},
+		{http.StatusTooManyRequests, connect.CodeResourceExhausted},
+		{http.StatusNotImplemented, connect.CodeUnimplemented},
+		{http.StatusServiceUnavailable, connect.CodeUnavailable},
+		{http.StatusGatewayTimeout, connect.CodeDeadlineExceeded},
+		{http.StatusInternalServerError, connect.CodeInternal},
+		{http.StatusTeapot, connect.CodeUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.statusCode), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error":             "test_error",
+					"error_description": "something went wrong",
+				})
+			}))
+			defer srv.Close()
+
+			client := newTestClient(t, srv)
+			_, err := client.Vehicles(context.Background(), rfmsv5.VehiclesRequest_builder{}.Build())
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var connectErr *connect.Error
+			if !errors.As(err, &connectErr) {
+				t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+			}
+			if connectErr.Code() != tt.wantCode {
+				t.Fatalf("expected code %v, got %v", tt.wantCode, connectErr.Code())
+			}
+		})
+	}
+}
+
+func TestRateLimitErrorPreservation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "rate_limit_exceeded",
+			"error_description": "too many requests",
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.Vehicles(context.Background(), rfmsv5.VehiclesRequest_builder{}.Build())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Verify it's a connect error with ResourceExhausted code.
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+	}
+	if connectErr.Code() != connect.CodeResourceExhausted {
+		t.Fatalf("expected CodeResourceExhausted, got %v", connectErr.Code())
+	}
+
+	// Verify the underlying rfms.Error is accessible with rate-limit info.
+	var rfmsErr *rfms.Error
+	if !errors.As(err, &rfmsErr) {
+		t.Fatalf("expected *rfms.Error via errors.As, got %T: %v", err, err)
+	}
+	if rfmsErr.RateLimitReset.Seconds() != 30 {
+		t.Fatalf("expected RateLimitReset=30s, got %v", rfmsErr.RateLimitReset)
+	}
+	if rfmsErr.Identifier != "rate_limit_exceeded" {
+		t.Fatalf("expected Identifier=rate_limit_exceeded, got %s", rfmsErr.Identifier)
+	}
+	if rfmsErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected StatusCode=429, got %d", rfmsErr.StatusCode)
+	}
+}

--- a/error.go
+++ b/error.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/way-platform/rfms-go/internal/openapi/rfmsv4oapi"
 )
 
@@ -31,7 +32,7 @@ type Error struct {
 	ErrorURI string
 }
 
-func newHTTPError(resp *http.Response) *Error {
+func newHTTPError(resp *http.Response) error {
 	result := &Error{
 		Method:     resp.Request.Method,
 		URL:        resp.Request.URL.String(),
@@ -59,7 +60,7 @@ func newHTTPError(resp *http.Response) *Error {
 			result.RateLimitReset = time.Duration(retryAfter) * time.Second
 		}
 	}
-	return result
+	return result.connectError()
 }
 
 // Error implements the error interface.
@@ -82,4 +83,35 @@ func (e *Error) Error() string {
 		e.Description,
 		e.ErrorURI,
 	)
+}
+
+func (e *Error) connectError() error {
+	return connect.NewError(httpStatusToConnectCode(e.StatusCode), e)
+}
+
+func httpStatusToConnectCode(statusCode int) connect.Code {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return connect.CodeInvalidArgument
+	case http.StatusUnauthorized:
+		return connect.CodeUnauthenticated
+	case http.StatusForbidden:
+		return connect.CodePermissionDenied
+	case http.StatusNotFound:
+		return connect.CodeNotFound
+	case http.StatusConflict:
+		return connect.CodeAlreadyExists
+	case http.StatusTooManyRequests:
+		return connect.CodeResourceExhausted
+	case http.StatusNotImplemented:
+		return connect.CodeUnimplemented
+	case http.StatusServiceUnavailable:
+		return connect.CodeUnavailable
+	case http.StatusGatewayTimeout:
+		return connect.CodeDeadlineExceeded
+	case http.StatusInternalServerError:
+		return connect.CodeInternal
+	default:
+		return connect.CodeUnknown
+	}
 }


### PR DESCRIPTION
## Summary

- Wrap `Error` in `connect.NewError()` via `connectError()` method (preserves `errors.As` for rate-limit info)
- Add HTTP-level `client_test.go` with `httptest.NewServer` coverage
- Tests verify all 3 methods, error code mapping, and rate-limit header preservation

## Motivation

Aligns with SDK conformance standard: consumers get standard Connect error codes while retaining access to rich error details (rate-limit reset duration) via `errors.As`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `errors.As(err, &rfms.Error{})` still works through connect wrapper
- [x] Rate-limit `Retry-After` header preserved in unwrapped error