### PR TITLE
refactor: remove Error struct, use plain connect errors

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -188,7 +188,7 @@ func TestErrorCodeMapping(t *testing.T) {
 	}
 }
 
-func TestRateLimitErrorPreservation(t *testing.T) {
+func TestRateLimitError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Retry-After", "30")
@@ -205,28 +205,11 @@ func TestRateLimitErrorPreservation(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-
-	// Verify it's a connect error with ResourceExhausted code.
 	var connectErr *connect.Error
 	if !errors.As(err, &connectErr) {
 		t.Fatalf("expected *connect.Error, got %T: %v", err, err)
 	}
 	if connectErr.Code() != connect.CodeResourceExhausted {
 		t.Fatalf("expected CodeResourceExhausted, got %v", connectErr.Code())
-	}
-
-	// Verify the underlying rfms.Error is accessible with rate-limit info.
-	var rfmsErr *rfms.Error
-	if !errors.As(err, &rfmsErr) {
-		t.Fatalf("expected *rfms.Error via errors.As, got %T: %v", err, err)
-	}
-	if rfmsErr.RateLimitReset.Seconds() != 30 {
-		t.Fatalf("expected RateLimitReset=30s, got %v", rfmsErr.RateLimitReset)
-	}
-	if rfmsErr.Identifier != "rate_limit_exceeded" {
-		t.Fatalf("expected Identifier=rate_limit_exceeded, got %s", rfmsErr.Identifier)
-	}
-	if rfmsErr.StatusCode != http.StatusTooManyRequests {
-		t.Fatalf("expected StatusCode=429, got %d", rfmsErr.StatusCode)
 	}
 }

--- a/error.go
+++ b/error.go
@@ -2,91 +2,37 @@ package rfms
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
-	"time"
 
 	"connectrpc.com/connect"
 	"github.com/way-platform/rfms-go/internal/openapi/rfmsv4oapi"
 )
 
-// Error is an error returned by the rFMS API.
-type Error struct {
-	// Method is the HTTP method used to make the request.
-	Method string
-	// URL is the URL of the request.
-	URL string
-	// Status is the HTTP status.
-	Status string
-	// StatusCode is the HTTP status code.
-	StatusCode int
-	// RateLimitReset is the duration until the rate limit is reset.
-	RateLimitReset time.Duration
-	// Identifier of the rFMS error.
-	Identifier string
-	// Description of the rFMS error.
-	Description string
-	// ErrorURI provides more information about the error.
-	ErrorURI string
-}
-
 func newHTTPError(resp *http.Response) error {
-	result := &Error{
-		Method:     resp.Request.Method,
-		URL:        resp.Request.URL.String(),
-		Status:     resp.Status,
-		StatusCode: resp.StatusCode,
-	}
+	var msg string
 	if data, err := io.ReadAll(resp.Body); err == nil {
 		var body rfmsv4oapi.ErrorObject
 		if err := json.Unmarshal(data, &body); err == nil {
+			parts := fmt.Sprintf("http %d", resp.StatusCode)
 			if body.Error != nil {
-				result.Identifier = *body.Error
+				parts += ": " + *body.Error
 			}
 			if body.ErrorDescription != nil {
-				result.Description = *body.ErrorDescription
+				parts += " - " + *body.ErrorDescription
 			}
-			if body.ErrorURI != nil {
-				result.ErrorURI = *body.ErrorURI
-			}
+			msg = parts
+		} else if len(data) > 0 {
+			msg = fmt.Sprintf("http %d: %s", resp.StatusCode, data)
 		} else {
-			result.Description = string(data)
+			msg = fmt.Sprintf("http %d", resp.StatusCode)
 		}
+	} else {
+		msg = fmt.Sprintf("http %d", resp.StatusCode)
 	}
-	if retryAfterHeader := resp.Header.Get("Retry-After"); retryAfterHeader != "" {
-		if retryAfter, err := strconv.Atoi(retryAfterHeader); err == nil {
-			result.RateLimitReset = time.Duration(retryAfter) * time.Second
-		}
-	}
-	return result.connectError()
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	if e.RateLimitReset > 0 {
-		return fmt.Sprintf(
-			"%s %s - %s: rate limit reset in %s",
-			e.Method,
-			e.URL,
-			e.Status,
-			e.RateLimitReset,
-		)
-	}
-	return fmt.Sprintf(
-		"%s %s: %s: %s - %s %s",
-		e.Method,
-		e.URL,
-		e.Status,
-		e.Identifier,
-		e.Description,
-		e.ErrorURI,
-	)
-}
-
-func (e *Error) connectError() error {
-	return connect.NewError(httpStatusToConnectCode(e.StatusCode), e)
+	return connect.NewError(httpStatusToConnectCode(resp.StatusCode), errors.New(msg))
 }
 
 func httpStatusToConnectCode(statusCode int) connect.Code {


### PR DESCRIPTION
## Summary

- Remove exported `Error` type (breaking change)
- Switch to simple pattern: `connect.NewError` with descriptive message
- Error details (identifier, description) are now part of the message string
- No consumer reads `RateLimitReset` — retry is handled by middleware

## Motivation

Follow-up to #27. The `Error` struct was preserved for backwards compatibility, but no consumer actually uses `errors.As` to extract rate-limit info or error identifiers. Removing the struct simplifies the API surface.

## Breaking change

Consumers using `errors.As(err, &rfms.Error{})` must switch to `connect.CodeOf(err)`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes